### PR TITLE
fixed typo model_mn

### DIFF
--- a/notebooks/pyglmnet_example.ipynb
+++ b/notebooks/pyglmnet_example.ipynb
@@ -350,7 +350,7 @@
     "model_mn = GLM(distr='multinomial', alpha=0.01, \n",
     "               reg_lambda=np.array([0.01]), verbose=False)\n",
     "model_mn.fit(X, y)\n",
-    "y_pred = model.predict(X, model_mn.fit_params[-1]).argmax(1)\n",
+    "y_pred = model_mn.predict(X, model_mn.fit_params[-1]).argmax(1)\n",
     "print (y_pred == y).mean()"
    ]
   }
@@ -371,7 +371,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.10"
+   "version": "2.7.11"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
small typo fixed in example notebook, `model` instead of `model_mn`