### PR TITLE
Pipeline compability tests

### DIFF
--- a/pyglmnet/pyglmnet.py
+++ b/pyglmnet/pyglmnet.py
@@ -316,8 +316,8 @@ class GLM(object):
             raise ValueError('Input data should be of type ndarray (got %s).'
                              % type(X))
 
-        n_samples = np.float(X.shape[0])
-        n_features = np.float(X.shape[1])
+        n_samples = X.shape[0]
+        n_features = X.shape[1]
 
         if self.distr == 'multinomial':
             y_bk = y.ravel()
@@ -432,8 +432,26 @@ class GLM(object):
         """
         return self.fit(X, y).predict(X)
 
-    def score(self, y, yhat, ynull=None, method='deviance'):
-        """Score the model.
+    def score(self, X, y):
+        """Scoring function compatible with sklearn.
+        If multiple regularization parameters are fit, an additional step is needed (e.g., take the mean)
+
+        Parameters
+        ----------
+        X: array, shape (n_samples, n_features)
+            Training data
+        y: array, shape (n_samples, [n_classes])
+            True value or label of training data
+
+        Returns
+        -------
+        Generate scores for each regularization parameter
+        """
+        yhats = self.predict(X)
+        return [self.general_score(y, yhat) for yhat in yhats]
+
+    def general_score(self, y, yhat, ynull=None, method='deviance'):
+        """General score function model.
 
         Parameters
         ----------

--- a/pyglmnet/pyglmnet.py
+++ b/pyglmnet/pyglmnet.py
@@ -432,27 +432,8 @@ class GLM(object):
         """
         return self.fit(X, y).predict(X)
 
-    def score(self, X, y):
-        """Scoring function compatible with sklearn.
-        If multiple regularization parameters are fit,
-        an additional step is needed (e.g., take the mean)
-
-        Parameters
-        ----------
-        X: array, shape (n_samples, n_features)
-            Training data
-        y: array, shape (n_samples, [n_classes])
-            True value or label of training data
-
-        Returns
-        -------
-        Generate scores for each regularization parameter
-        """
-        yhats = self.predict(X)
-        return [self.general_score(y, yhat) for yhat in yhats]
-
-    def general_score(self, y, yhat, ynull=None, method='deviance'):
-        """General score function model.
+    def score(self, y, yhat, ynull=None, method='deviance'):
+        """Score the model.
 
         Parameters
         ----------
@@ -465,25 +446,56 @@ class GLM(object):
         method : str
             One of 'pseudo_R2' or 'deviance'
         """
-        y = y.ravel()
-        if self.distr != 'multinomial':
-            yhat = yhat.ravel()
 
-        L1 = utils.log_likelihood(y, yhat, self.distr)
-        if self.distr in ['poisson', 'poissonexp']:
-            LS = utils.log_likelihood(y, y, self.distr)
-        else:
-            LS = 0
+        if (self.distr != 'multinomial' and len(yhat.shape) == 1) or \
+                (self.distr == 'multinomial' and len(yhat.shape) == 2):
 
-        if method == 'deviance':
-            score = -2 * (L1 - LS)
-        elif method == 'pseudo_R2':
-            L0 = utils.log_likelihood(y, ynull, self.distr)
+            y = y.ravel()
+            if self.distr != 'multinomial':
+                yhat = yhat.ravel()
+
+            L1 = utils.log_likelihood(y, yhat, self.distr)
             if self.distr in ['poisson', 'poissonexp']:
-                score = 1 - (LS - L1) / (LS - L0)
+                LS = utils.log_likelihood(y, y, self.distr)
             else:
-                score = 1 - L1 / L0
+                LS = 0
 
+            if method == 'deviance':
+                score = -2 * (L1 - LS)
+            elif method == 'pseudo_R2':
+                L0 = utils.log_likelihood(y, ynull, self.distr)
+                if self.distr in ['poisson', 'poissonexp']:
+                    score = 1 - (LS - L1) / (LS - L0)
+                else:
+                    score = 1 - L1 / L0
+
+        elif (self.distr != 'multinomial' and len(yhat.shape) > 1) or \
+                (self.distr == 'multinomial' and len(yhat.shape) > 2):
+            y = y.ravel()
+            score = list()
+
+            if self.distr in ['poisson', 'poissonexp']:
+                LS = utils.log_likelihood(y, y, self.distr)
+            else:
+                LS = 0
+            if(method == 'pseudo_R2'):
+                L0 = utils.log_likelihood(y, ynull, self.distr)
+
+            for idx in range(yhat.shape[0]):
+
+                if self.distr != 'multinomial':
+                    yhat_this = (yhat[idx, :]).ravel()
+                else:
+                    yhat_this = yhat[idx, :, :]
+                L1 = utils.log_likelihood(y, yhat_this, self.distr)
+
+                if method == 'deviance':
+                    score.append(-2 * (L1 - LS))
+                elif method == 'pseudo_R2':
+                    if self.distr in ['poisson', 'poissonexp']:
+                        score.append(1 - (LS - L1) / (LS - L0))
+                    else:
+                        score.append(1 - L1 / L0)
         return score
 
     def simulate(self, beta0, beta, X):

--- a/pyglmnet/pyglmnet.py
+++ b/pyglmnet/pyglmnet.py
@@ -434,7 +434,8 @@ class GLM(object):
 
     def score(self, X, y):
         """Scoring function compatible with sklearn.
-        If multiple regularization parameters are fit, an additional step is needed (e.g., take the mean)
+        If multiple regularization parameters are fit,
+        an additional step is needed (e.g., take the mean)
 
         Parameters
         ----------

--- a/tests/test_pyglmnet.py
+++ b/tests/test_pyglmnet.py
@@ -72,8 +72,12 @@ def simple_cv_scorer(obj, X, y):
     """Simple scorer takes average pseudo-R2 from regularization path"""
     yhats = obj.predict(X)
     ynull = np.zeros(y.shape) * y.mean()
-    return np.mean([obj.score(y, yhat, ynull, method='pseudo_R2')
-                   for yhat in yhats])
+    if hasattr(obj, '_final_estimator'):
+        return np.mean([obj._final_estimator.score(y, yhat, ynull, method='pseudo_R2')
+                       for yhat in yhats])
+    else:
+        return np.mean([obj.score(y, yhat, ynull, method='pseudo_R2')
+                        for yhat in yhats])
 
 
 def test_cv():

--- a/tests/test_pyglmnet.py
+++ b/tests/test_pyglmnet.py
@@ -3,6 +3,7 @@ import scipy.sparse as sps
 from sklearn.cross_validation import KFold, cross_val_score
 from sklearn.datasets import make_regression
 from sklearn.preprocessing import StandardScaler
+from sklearn.pipeline import Pipeline
 
 from nose.tools import assert_true, assert_equal, assert_raises
 from numpy.testing import assert_allclose
@@ -56,7 +57,7 @@ def test_glmnet():
     y_pred = glm[2].predict(scaler.transform(X_train))
     assert_equal(y_pred.shape, (X_train.shape[0], ))
     assert_raises(IndexError, glm.__getitem__, [2])
-    glm.score(y_train, y_pred)
+    glm.general_score(y_train, y_pred)
 
     # don't allow slicing if model has not been fit yet.
     glm_poisson = GLM(distr='poisson')
@@ -67,28 +68,11 @@ def test_glmnet():
     assert_raises(ValueError, glm_poisson.fit_predict, X_train[None, ...], y_train)
 
 
-def simple_cv_scorer(obj, X, y):
+def simple_cv_scorer(estimator, X, y):
     """Simple scorer takes average pseudo-R2 from regularization path"""
-    yhats = obj.predict(X)
-    ynull = np.zeros(y.shape) * y.mean()
-    return np.mean([obj.score(y, yhat, ynull, method='pseudo_R2')
-                   for yhat in yhats])
+    scores = estimator.score(X, y)
+    return np.mean(scores)
 
-
-def test_cv():
-    """Simple CV check"""
-    # XXX: don't use scikit-learn for tests.
-    X, y = make_regression()
-
-    glm_normal = GLM(distr='normal', alpha=0.01,
-                     reg_lambda=[0.0, 0.1, 0.2])
-    glm_normal.fit(X, y)
-
-    cv = KFold(X.shape[0], 5)
-    # check that it returns 5 scores
-
-    assert_equal(len(cross_val_score(glm_normal, X, y, cv=cv,
-                 scoring=simple_cv_scorer)), 5)
 
 def test_multinomial():
     """Test all multinomial functionality"""
@@ -110,12 +94,33 @@ def test_multinomial():
     # uniform prediction
     ynull = np.ones(yhat.shape) / yhat.shape[1]
     # pseudo_R2 should be greater than 0
-    assert_true(glm_mn.score(y, yhat, ynull, method='pseudo_R2') > 0.)
-    glm_mn.score(y, yhat)
+    assert_true(glm_mn.general_score(y, yhat, ynull, method='pseudo_R2') > 0.)
+    glm_mn.general_score(y, yhat)
     assert_equal(len(glm_mn.simulate(glm_mn.fit_[0]['beta0'],
                                   glm_mn.fit_[0]['beta'],
                                   X)),
                  X.shape[0])
     # these should raise an exception
-    assert_raises(ValueError, glm_mn.score, y, y, y, 'pseudo_R2')
-    assert_raises(ValueError, glm_mn.score, y, y, None, 'deviance')
+    assert_raises(ValueError, glm_mn.general_score, y, y, y, 'pseudo_R2')
+    assert_raises(ValueError, glm_mn.general_score, y, y, None, 'deviance')
+
+
+def test_sklearn_compatibility():
+    X, y = make_regression(n_samples=1000, n_features=10)
+
+    # Test whether cross validation works
+    glm_normal = GLM(distr='normal', alpha=0.01,
+                     reg_lambda=[0.0, 0.1, 0.2])
+    glm_normal.fit(X, y)
+    cv = KFold(X.shape[0], 5)
+    # check that it returns 5 scores
+    assert_equal(len(cross_val_score(glm_normal, X, y, cv=cv,
+                                     scoring=simple_cv_scorer)), 5)
+
+    # Test sklearn pipelines
+    scaler = StandardScaler()
+    glm = GLM(distr='normal', alpha=0.01,
+              reg_lambda=[0.0, 0.1, 0.2])
+    clf = Pipeline([("scaler", scaler), ("glm", glm)])
+    assert_equal(len(cross_val_score(clf, X, y, cv=cv,
+                                     scoring=simple_cv_scorer)), 5)


### PR DESCRIPTION
The old `score` function did not work with `Pipeline` because it needs to follow `sklearn`'s [structure](http://scikit-learn.org/stable/modules/generated/sklearn.linear_model.ElasticNetCV.html#sklearn.linear_model.ElasticNetCV.score). 

The old `score` method is now called `general_score`. 

See the test `test_sklearn_compatibility` to see how to integrate `pyglmnet` with `Pipeline`