### PR TITLE
rescaled betas to prevent overflow

### DIFF
--- a/pyglmnet/pyglmnet.py
+++ b/pyglmnet/pyglmnet.py
@@ -330,8 +330,9 @@ class GLM(object):
         n_classes = y.shape[1] if self.distr == 'multinomial' else 1
 
         # Initialize parameters
-        beta0_hat = np.random.normal(0.0, 1.0, n_classes)
-        beta_hat = np.random.normal(0.0, 1.0, [n_features, n_classes])
+        beta0_hat = 1/ (n_features + 1) * np.random.normal(0.0, 1.0, n_classes)
+        beta_hat = 1/ (n_features + 1) * \
+                    np.random.normal(0.0, 1.0, [n_features, n_classes])
         fit_params = list()
 
         logger.info('Looping through the regularization path')

--- a/pyglmnet/pyglmnet.py
+++ b/pyglmnet/pyglmnet.py
@@ -330,9 +330,10 @@ class GLM(object):
         n_classes = y.shape[1] if self.distr == 'multinomial' else 1
 
         # Initialize parameters
-        beta0_hat = 1/ (n_features + 1) * np.random.normal(0.0, 1.0, n_classes)
-        beta_hat = 1/ (n_features + 1) * \
-                    np.random.normal(0.0, 1.0, [n_features, n_classes])
+        beta0_hat = 1 / (n_features + 1) * \
+            np.random.normal(0.0, 1.0, n_classes)
+        beta_hat = 1 / (n_features + 1) * \
+            np.random.normal(0.0, 1.0, [n_features, n_classes])
         fit_params = list()
 
         logger.info('Looping through the regularization path')

--- a/tests/test_pyglmnet.py
+++ b/tests/test_pyglmnet.py
@@ -22,11 +22,9 @@ def test_glmnet():
     beta = sps.rand(n_features, 1, density=density).toarray()
 
     distrs = ['poisson', 'poissonexp', 'normal', 'binomial']
-    learning_rates = {'poisson': 2e-1, 'poissonexp': 1e-1, 'normal': 1e-2, 'binomial': 2e-1}
+    learning_rate = 2e-1
     for distr in distrs:
 
-        # FIXME: why do we need such different learning rates?
-        learning_rate = learning_rates[distr]
         glm = GLM(distr, learning_rate=learning_rate)
 
         assert_true(repr(glm))


### PR DESCRIPTION
We have good gradient explosion safeguards, but the best safeguard is good initialization of parameters. Here, I rescale the betas by `1 / (n_features+1)`. Also helps by not having to tune learning rates for different `distr`. A default of `2e-1` works well.