### PR TITLE
[MRG] Refactored score function, tests and examples to be pipeline compatible

### DIFF
--- a/examples/api/plot_poisson.py
+++ b/examples/api/plot_poisson.py
@@ -151,18 +151,16 @@ plt.show()
 # ^^^^^^^^^^^^^^^
 # The GLM class provides two metrics to evaluate the goodness of fit: ``deviance``
 # and ``pseudo_R2``. Both these metrics are implemented in the ``score()`` method.
-# The default metric, ``deviance`` requires the true targets and the predicted targets
-# as inputs. ``pseudo_R2`` additionally requires a null model, for which the
-# best estimate is the mean of the target variables in the training set.
 
 ##########################################################
 
 # Compute model deviance
-Dr = glm_poisson[-1].score(yr, yrhat)
-Dt = glm_poisson[-1].score(yt, ythat)
+Dr = glm_poisson[-1].score(Xr, yr)
+Dt = glm_poisson[-1].score(Xt, yt)
 print('Dr = %f' % Dr, 'Dt = %f' % Dt)
 
 # Compute pseudo_R2s
-R2r = glm_poisson[-1].score(yr, yrhat, np.mean(yr), method='pseudo_R2')
-R2t = glm_poisson[-1].score(yt, ythat, np.mean(yr), method='pseudo_R2')
+glm_poisson.score_metric = 'pseudo_R2'
+R2r = glm_poisson[-1].score(Xr, yr)
+R2t = glm_poisson[-1].score(Xt, yt)
 print('  R2r =  %f' % R2r, ' R2r = %f' % R2t)

--- a/examples/api/plot_poissonexp.py
+++ b/examples/api/plot_poissonexp.py
@@ -117,7 +117,7 @@ from pyglmnet import GLM
 # create regularization parameters for model
 reg_lambda = np.logspace(np.log(0.5), np.log(0.01), 10, base=np.exp(1))
 glm_poissonexp = GLM(distr='poissonexp', verbose=False, alpha=0.05,
-            max_iter=1000, learning_rate=2e-1,
+            max_iter=1000, learning_rate=2e-1, score_metric='pseudo_R2',
             reg_lambda=reg_lambda, eta=4.0)
 
 
@@ -176,4 +176,4 @@ plt.show()
 
 ########################################################
 
-print(m.score(yt, ythat, np.mean(yr), method='pseudo_R2'))
+print(m.score(Xt, yt))

--- a/tests/test_pyglmnet.py
+++ b/tests/test_pyglmnet.py
@@ -210,19 +210,19 @@ def test_multinomial():
     ynull = np.ones(yhat.shape) / yhat.shape[1]
 
     # pseudo_R2 should be greater than 0
-    assert_true(glm_mn.score(X, y) > 0.)
-    glm_mn.score(X, y)
+    assert_true(glm_mn[-1].score(X, y) > 0.)
     assert_equal(len(glm_mn.simulate(glm_mn.fit_[0]['beta0'],
                                   glm_mn.fit_[0]['beta'],
                                   X)),
                  X.shape[0])
 
     # check that score is computed for sliced estimator
-    assert_true(isinstance(glm_mn[-1].score(X, y), float))
+    scorelist = glm_mn[-1].score(X, y)
+    assert_equal(scorelist.shape[0], 1)
 
     # check that score is computed for all lambdas
-    assert_equal(len(glm_mn.score(X, y)),
-                 y_pred.shape[0])
+    scorelist = glm_mn.score(X, y)
+    assert_equal(scorelist.shape[0], y_pred.shape[0])
 
 def test_cdfast():
     """Test all functionality related to fast coordinate descent"""

--- a/tests/test_pyglmnet.py
+++ b/tests/test_pyglmnet.py
@@ -30,7 +30,7 @@ def test_tikhonov():
     beta = np.random.multivariate_normal(np.zeros(n_features), PriorCov)
 
     # sample train and test data
-    glm_sim = GLM(distr='poisson')
+    glm_sim = GLM(distr='poisson', score_metric='pseudo_R2')
     X = np.random.randn(n_samples, n_features)
     y = glm_sim.simulate(beta0, beta, X)
 
@@ -44,7 +44,12 @@ def test_tikhonov():
     Tau = 1. / np.sqrt(np.float(n_samples)) * Tau / Tau.max()
 
     # fit model with batch gradient
-    glm_tikhonov = GLM(distr='poisson', alpha=0.0, Tau=Tau, solver='batch-gradient', tol=1e-5)
+    glm_tikhonov = GLM(distr='poisson',
+                       alpha=0.0,
+                       Tau=Tau,
+                       solver='batch-gradient',
+                       tol=1e-5,
+                       score_metric='pseudo_R2')
     glm_tikhonov.fit(Xtrain, ytrain);
 
     ytrain_hat = glm_tikhonov[-1].predict(Xtrain)
@@ -52,11 +57,16 @@ def test_tikhonov():
 
     R2_train = dict()
     R2_test = dict()
-    R2_train['tikhonov'] = glm_tikhonov[-1].score(ytrain, ytrain_hat, np.mean(ytrain), method='pseudo_R2')
-    R2_test['tikhonov'] = glm_tikhonov[-1].score(ytest, ytest_hat, np.mean(ytrain), method='pseudo_R2')
+    R2_train['tikhonov'] = glm_tikhonov[-1].score(Xtrain, ytrain)
+    R2_test['tikhonov'] = glm_tikhonov[-1].score(Xtest, ytest)
 
     # fit model with cdfast
-    glm_tikhonov = GLM(distr='poisson', alpha=0.0, Tau=Tau, solver='cdfast', tol=1e-5)
+    glm_tikhonov = GLM(distr='poisson',
+                       alpha=0.0,
+                       Tau=Tau,
+                       solver='cdfast',
+                       tol=1e-5,
+                       score_metric='pseudo_R2')
     glm_tikhonov.fit(Xtrain, ytrain)
 
     ytrain_hat = glm_tikhonov[-1].predict(Xtrain)
@@ -64,8 +74,8 @@ def test_tikhonov():
 
     R2_train = dict()
     R2_test = dict()
-    R2_train['tikhonov'] = glm_tikhonov[-1].score(ytrain, ytrain_hat, np.mean(ytrain), method='pseudo_R2')
-    R2_test['tikhonov'] = glm_tikhonov[-1].score(ytest, ytest_hat, np.mean(ytrain), method='pseudo_R2')
+    R2_train['tikhonov'] = glm_tikhonov[-1].score(Xtrain, ytrain)
+    R2_test['tikhonov'] = glm_tikhonov[-1].score(Xtest, ytest)
 
 
 def test_group_lasso():
@@ -113,13 +123,14 @@ def test_glmnet():
 
     distrs = ['poisson', 'poissonexp', 'normal', 'binomial']
     solvers = ['batch-gradient', 'cdfast']
+    score_metric = 'pseudo_R2'
     learning_rate = 2e-1
 
     for solver in solvers:
         for distr in distrs:
 
             glm = GLM(distr, learning_rate=learning_rate,
-                      solver=solver)
+                      solver=solver, score_metric=score_metric)
 
             assert_true(repr(glm))
 
@@ -146,7 +157,7 @@ def test_glmnet():
     y_pred = glm[2].predict(scaler.transform(X_train))
     assert_equal(y_pred.shape, (X_train.shape[0], ))
     assert_raises(IndexError, glm.__getitem__, [2])
-    glm.score(y_train, y_pred)
+    glm.score(X_train, y_train)
 
     # don't allow slicing if model has not been fit yet.
     glm_poisson = GLM(distr='poisson')
@@ -160,10 +171,7 @@ def test_glmnet():
 def simple_cv_scorer(obj, X, y):
     """Simple scorer takes average pseudo-R2 from regularization path"""
     yhats = obj.predict(X)
-    ynull = np.zeros(y.shape) * y.mean()
-    return np.mean([obj.score(y, yhat, ynull, method='pseudo_R2')
-                   for yhat in yhats])
-
+    return np.mean([obj.score(X, y) for yhat in yhats])
 
 def test_cv():
     """Simple CV check"""
@@ -175,8 +183,8 @@ def test_cv():
     glm_normal.fit(X, y)
 
     cv = KFold(X.shape[0], 5)
-    # check that it returns 5 scores
 
+    # check that it returns 5 scores
     assert_equal(len(cross_val_score(glm_normal, X, y, cv=cv,
                  scoring=simple_cv_scorer)), 5)
 
@@ -197,18 +205,24 @@ def test_multinomial():
 
     # pick one as yhat
     yhat = y_pred[0]
+
     # uniform prediction
     ynull = np.ones(yhat.shape) / yhat.shape[1]
+
     # pseudo_R2 should be greater than 0
-    assert_true(glm_mn.score(y, yhat, ynull, method='pseudo_R2') > 0.)
-    glm_mn.score(y, yhat)
+    assert_true(glm_mn.score(X, y) > 0.)
+    glm_mn.score(X, y)
     assert_equal(len(glm_mn.simulate(glm_mn.fit_[0]['beta0'],
                                   glm_mn.fit_[0]['beta'],
                                   X)),
                  X.shape[0])
-    # these should raise an exception
-    assert_raises(ValueError, glm_mn.score, y, y, y, 'pseudo_R2')
-    assert_raises(ValueError, glm_mn.score, y, y, None, 'deviance')
+
+    # check that score is computed for sliced estimator
+    assert_true(isinstance(glm_mn[-1].score(X, y), float))
+
+    # check that score is computed for all lambdas
+    assert_equal(len(glm_mn.score(X, y)),
+                 y_pred.shape[0])
 
 def test_cdfast():
     """Test all functionality related to fast coordinate descent"""


### PR DESCRIPTION
- The `GLM` class accepts an attribute `score_metric` to decide whether to return `'deviance'` or `'pseudo_R2'`. Default is `'deviance'`
- After `fit()` the mean of the training set is stored in `self.ynull_`. This is used to compute 'pseudo_R2'.
- If a list of estimators calls `score()` it returns a list of floats, one for each `reg_lambda`.
- Tests verify that `score()` cannot be called unless `fit()` is run.
- The use of `score()` has been changed in all appropriate examples.